### PR TITLE
dsa code optimized

### DIFF
--- a/lightdsa/__init__.py
+++ b/lightdsa/__init__.py
@@ -1,6 +1,7 @@
 # built-in dependencies
 from typing import Optional, Tuple, Union, BinaryIO, cast
 import json
+import sys
 
 # project dependencies
 from lightdsa.interfaces.signatures import Signature
@@ -11,17 +12,23 @@ from lightdsa.algorithms.dsa import DSA
 from lightdsa.commons.transformation import integerize
 from lightdsa.commons.logger import Logger
 
-__version__ = "0.0.2"
+VERSION = "0.0.3"
 
 
 logger = Logger(module="lightdsa/__init__.py")
 
+# Not to get ValueError: Exceeds the limit (4300) for integer string conversion
+if hasattr(sys, "set_int_max_str_digits"):
+    sys.set_int_max_str_digits(0)
 
-# pylint: disable=eval-used
+
+# pylint: disable=eval-used, unknown-option-value, too-many-positional-arguments
 class LightDSA:
     """
     Build a LightDSA object
     """
+
+    __version__ = VERSION
 
     def __init__(
         self,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r", encoding="utf-8") as f:
 
 setuptools.setup(
     name="lightdsa",
-    version="0.0.2",
+    version="0.0.3",
     author="Sefik Ilkin Serengil",
     author_email="serengil@gmail.com",
     description="A Lightweight Digital Signature Algorithm Library for Python",


### PR DESCRIPTION
# Tickets

- https://github.com/serengil/LightDSA/issues/3
- https://github.com/serengil/LightDSA/issues/2

# What has been done

- DSA code optimized, its default key size is set to 112-bit security level (safe until 2030)
- DSA with 256-bit security level was failing because of the integer limit

# How to test

```shell
make lint && make test
```