### PR TITLE
forgotten test cases for forms and curves added

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -99,7 +99,7 @@ def test_custom_curves():
         ("ecdsa", "weierstrass", "bn638"),
     ]
     for algorithm, form, curve in configs:
-        dsa = LightDSA(algorithm_name="rsa")
+        dsa = LightDSA(algorithm_name=algorithm, form_name=form, curve_name=curve)
         m = 23
         signature = dsa.sign(m)
         assert dsa.verify(m, signature) is True


### PR DESCRIPTION
With this PR, we added forgotten test cases for custom forms and curves because of a typo.